### PR TITLE
Add more bingo options and refactor option classes

### DIFF
--- a/bingo/web/bingo.js
+++ b/bingo/web/bingo.js
@@ -133,7 +133,7 @@ class Format extends Option {
 
 /// Wraps another option and gives it a specific weight.
 class Weight extends Option {
-	construction(weight, option) {
+	constructor(weight, option) {
 		super();
 		this.weight = weight;
 		this.option = option;

--- a/bingo/web/bingo.js
+++ b/bingo/web/bingo.js
@@ -1,26 +1,49 @@
 const INACTIVE = 'bingo-inactive';
 const ACTIVE = 'bingo-active';
 
-class Select {
-	constructor(items) {
-		this.items = items;
-	}
-
-	count() {
-		return this.items
-			.map(item => typeof item === 'object' ? item : 1)
-			.reduce((a, b) => a + b);
-	}
-
-	select(rng) {
-		const choice = rng.pickone(this.items);
-		return typeof choice === 'object' ? choice.select(rng) : choice;
-	}
+/// The abstract base class of various ways of describing bingo options.
+///
+/// Option classes are immutable. When it's time to generate squares for a new
+/// board, the `build()` method is called to return a mutable generator that can
+/// track state over time (for example, to ensure the same option isn't selected
+/// more than once).
+class Option {
+  /// Returns a generator object given a random number generator. In addition to
+  /// storing private state, this object must expose a `select()` method that
+  /// returns either a new unique option or null/undefined to indicate that the
+  /// generator is exhausted and cannot generate any more squares.
+  ///
+  /// It may also expose a `weight` getter that's used to determine its relative
+  /// likelihood of being selected. If it doesn't, the weight defaults to 100.
+  /* build(rng); */
 }
 
-class SelectOne extends Select {
-	count() {
-		return 1;
+class Select extends Option {
+	constructor(items) {
+		super();
+		this.items = items.map(item => item instanceof Option ? item : new Unique(item));
+	}
+
+	build(rng) {
+		return {
+			generators: this.items.map(item => item.build(rng)),
+			select() {
+				while (this.generators.length > 0) {
+					const indices = Object.keys(this.generators);
+					const i = rng.weighted(indices, this.generators.map(generator => generator.weight ?? 100));
+					const result = this.generators[i].select();
+					if (result) return result;
+
+					this.generators.splice(i, 1);
+				}
+				return null;
+			},
+			toString: () => this.toString(),
+		};
+	}
+
+	toString() {
+		return `S([${this.items}])`;
 	}
 }
 
@@ -29,81 +52,137 @@ class SelectN extends Select {
 		super(items);
 		this.n = n;
 	}
-	count() {
-		return this.n;
+
+	build(rng) {
+		return {
+			parent: super.build(rng),
+			n: this.n,
+			select() {
+				if (this.n === 0) return null;
+				this.n--;
+				return this.parent.select();
+			},
+			toString: () => this.toString(),
+		};
+	}
+
+	toString() {
+		return `N(${this.n}, [${this.items}])`;
 	}
 }
 
-class Range {
+class Range extends Option {
 	constructor(min, max) {
+		super();
 		this.min = min;
 		this.max = max;
 	}
 
-	count() {
-		return 1;
+	build(rng) {
+		return {
+			min: this.min,
+			max: this.max,
+			select() {
+				if (this.done) return null;
+				this.done = true;
+				return rng.integer({min: this.min, max: this.max});
+			},
+			toString: () => this.toString(),
+		};
 	}
 
-	select(rng) {
-		return rng.integer({ min: this.min, max: this.max })
+	toString() {
+		return `R(${this.min}, ${this.max})`;
+	}
+}
+
+/// Formats a string with values selected from other `Option` objects.
+class Format extends Option {
+	constructor(format, ...options) {
+		super();
+		this.format = format;
+		this.options = options;
+	}
+
+	build(rng) {
+		return {
+			format: this.format,
+			options: this.options.map(option => option.build(rng)),
+			select() {
+				var str = this.format;
+				for (let i = 0; i < this.options.length; i++) {
+					// Allow the option format to specify the same number multiple
+					// times to select different values from the options.
+					const occurrences = str.split(`{${i}}`).length - 1;
+					for (let j = 0; j < occurrences; j++) {
+						const choice = this.options[i].select();
+						if (!choice) return null;
+						str = str.replace(`{${i}}`, choice);
+					}
+				}
+				return str;
+			},
+			toString: () => this.toString(),
+		};
+	}
+
+	toString() {
+		return `F(${JSON.stringify(this.format)}, ${this.options})`;
+	}
+}
+
+/// Wraps another option and gives it a specific weight.
+class Weight extends Option {
+	construction(weight, option) {
+		super();
+		this.weight = weight;
+		this.option = option;
+	};
+
+	build(rng) {
+		return {
+			...this.option.build(rng),
+			weight: this.weight,
+			toString: () => this.toString(),
+		};
+	}
+
+	toString() {
+		return `W(${this.weight}, ${this.option})`;
+	}
+}
+
+/// A single bingo option that can be selected exactly once. This doesn't need
+/// to be instantiated manually, since `new Select()` will automatically
+/// translate plain strings into `Unique` options.
+class Unique extends Option {
+	constructor(value) {
+		super();
+		this.value = value;
+	}
+
+	build(rng) {
+		return {
+			value: this.value,
+			select() {
+				if (this.done) return null;
+				this.done = true;
+				return this.value;
+			},
+			toString: () => this.toString(),
+		};
+	}
+
+	toString() {
+		return JSON.stringify(this.value);
 	}
 }
 
 function S(items) { return new Select(items); }
-function O(items) { return new SelectOne(items); }
+function O(items) { return new SelectN(1, items); }
 function N(n, items) { return new SelectN(n, items); }
 function R(min, max) { return new Range(min, max); }
-
-class Option {
-	// Weight starts at 100 so that any value between 0 to 100 will give a relative percentage that
-	// can be somewhat intuitively understood.
-	constructor(desc, weight) {
-		if (!weight) throw new Error("An Option must have a weight.");
-
-		this.desc = desc;
-		this.weight = weight;
-		this.options = [...arguments].slice(2);
-	}
-
-	count() {
-		if (this.options.length > 0) {
-			var m = 1;
-			for (var k = 0; k < this.options.length; ++k) {
-				m *= this.options[k].count();
-			}
-			return m;
-		} else {
-			return 1;
-		}
-	}
-
-	select(rng) {
-		if (this.options.length > 0) {
-			var str = this.desc;
-			for (var i = 0; i < this.options.length; ++i) {
-				// Allow the option format to specify the same number multiple
-				// times to select different values from the options.
-				const seen = new Set();
-				str = str.replaceAll(`{${i}}`, () => {
-					while (true) {
-						const choice = this.options[i].select(rng);
-						if (seen.has(choice)) continue;
-						seen.add(choice);
-						return choice;
-					}
-				});
-			}
-
-			return str;
-		} else {
-			return this.desc;
-		}
-	}
-}
-
-function randInt(i) {
-	return Math.floor(Math.random() * i);
-}
+function F(format, ...options) { return new Format(format, ...options); }
 
 class CellState {
 	constructor() {
@@ -126,8 +205,8 @@ class CellState {
 }
 
 class Bingo {
-	constructor(options, seed=-1) {
-		this.options = options;
+	constructor(option, seed=-1) {
+		this.option = option;
 		this.goals = []
 		if (seed < 0) {
 			this.rng = chance;
@@ -153,31 +232,18 @@ class Bingo {
 	}
 
 	generate() {
-		var choices = [];
-		var counts  = new Map();
-		const table = document.getElementById('bingo-table');
-		const weights = this.options.map(x => x.weight);
-		console.log(weights.toString())
-
+		const choices = [];
+		const generator = this.option.build(this.rng);
 		for (var i = 0; i < 5; ++i) {
 			for (var k = 0; k < 5; ++k) {
 				while (true) {
-					const option = this.rng.weighted(this.options, weights);
-					if (!counts.has(option)) counts.set(option, 0);
-					const count = counts.get(option);
-					if (count >= option.count()) continue;
-
-					var opt = option.select(this.rng);
-					if (choices.includes(opt)) continue;
-
-					counts.set(option, count + 1);
-					choices.push(opt);
-					this.goals.push({"name": opt});
+					var choice = generator.select();
+					choices.push(choice);
+					this.goals.push({"name": choice});
 					break;
 				}
 			}
 		}
-		//shuffleArray(this.goals);
 		this.rng.shuffle(this.goals);
 	}
 
@@ -197,14 +263,4 @@ class Bingo {
 			}
 		}	
 	}
-}
-
-
-
-
-function shuffleArray(array) {
-    for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
-    }
 }

--- a/bingo/web/ds3/index.js
+++ b/bingo/web/ds3/index.js
@@ -1,5 +1,5 @@
 const OPTIONS = [
-	new Option('Find {0}', S([
+	F('Find {0}', S([
 		"Firekeeper's Eyes",
 		"Soul a Firekeeper",
 		"Dragon Torso Stone",
@@ -8,12 +8,12 @@ const OPTIONS = [
 		"Twinkling Dragon Head Stone",
 		"Coiled Sword Fragment",
 	])),
-	new Option("Complete Siegward's Questline."),
-	new Option('Kill {0} Monstrosities of Sin', O([1, 2, 3])),
-	new Option('Kill {0} Pontiff Beasts', O([1, 2, 3])),
-	new Option('Kill {0} Deep Accursed', O([1, 2])),
-	new Option('Kill {0} Demons', O([1, 2, 3, 4])),
-	new Option('Find {0}', N(5, [
+	F("Complete Siegward's Questline."),
+	F('Kill {0} Monstrosities of Sin', O([1, 2, 3])),
+	F('Kill {0} Pontiff Beasts', O([1, 2, 3])),
+	F('Kill {0} Deep Accursed', O([1, 2])),
+	F('Kill {0} Demons', O([1, 2, 3, 4])),
+	F('Find {0}', N(5, [
 		'Irithyll Straight Sword',
 		'Irithyll Rapier',
 		"Anri's Straightsword",
@@ -81,12 +81,12 @@ const OPTIONS = [
 		"White Hair Talisman",
 		"Caitha's Chime"
 	])),
-	new Option('Collect {0} Estus Shards', O([5, 6, 7, 8, 9, 10, 11, 12, 13, 14])),
-	new Option('Collect {0} Undead Bone Shards', O([5, 6, 7, 8, 9])),
-	new Option('Do not exceed level {0}', O([40, 50, 60, 70, 80])),
-	new Option('Possess {0} souls at some point', R(100000, 400000)),
-	new Option("Kill {0} Elder Ghru", O([1, 2, 3, 4, 5, 6])),
-	new Option("Use {0}'s Soul", N(3, [
+	F('Collect {0} Estus Shards', O([5, 6, 7, 8, 9, 10, 11, 12, 13, 14])),
+	F('Collect {0} Undead Bone Shards', O([5, 6, 7, 8, 9])),
+	F('Do not exceed level {0}', O([40, 50, 60, 70, 80])),
+	F('Possess {0} souls at some point', R(100000, 400000)),
+	F("Kill {0} Elder Ghru", O([1, 2, 3, 4, 5, 6])),
+	F("Use {0}'s Soul", N(3, [
 		"Vordt",
 		"Greatwood",
 		"Gundyr",
@@ -108,7 +108,7 @@ const OPTIONS = [
 		"Nameless King",
 		"Soul of Cinder"
 	])),
-	new Option("Defeat {0} with a {1} only", 
+	F("Defeat {0} with a {1} only", 
 		O([
 			"Soul of Cinder",
 			"Vordt",

--- a/bingo/web/sekiro/index.js
+++ b/bingo/web/sekiro/index.js
@@ -1,19 +1,19 @@
-const OPTIONS = [
-	new Option('Find {0}', 100, S([
+const OPTIONS = S([
+	F('Find {0}', S([
 		"Gokan's Spiritfall",
 		"Yashariku's Spiritfall",
 		"Ako's Spiritfall",
 		"Gachiin's Spiritfall",
 		"Ungo's Spiritfall"
 	])),
-	new Option("Complete Kotaro's questline (any ending)", 100),
-	new Option('{0}', 100, N(3, [
-		new Option('Kill {0} Ashina Generals', 100, O([2, 3])),
-		new Option('Kill {0} Shichimen Warriors', 100, O([2, 3])),
-		new Option('Kill {0} Headless', 100, O([1, 2, 3, 4, 5])),
-		new Option('Kill {0} Lone Shadows', 100, O([2, 3, 4])),
-		new Option('Kill {0} Drunkards, Gluttons, and/or Red Guards', 100, O([2, 3, 4])),
-		new Option('Kill both {0}', 100, S([
+	"Complete Kotaro's questline (any ending)",
+	N(3, [
+		F('Kill {0} Ashina Generals', O([2, 3])),
+		F('Kill {0} Shichimen Warriors', O([2, 3])),
+		F('Kill {0} Headless', O([1, 2, 3, 4, 5])),
+		F('Kill {0} Lone Shadows', O([2, 3, 4])),
+		F('Kill {0} Drunkards, Gluttons, and/or Red Guards', O([2, 3, 4])),
+		F('Kill both {0}', S([
 			'Centipedes',
 			'Snake-Eyes',
 			'Seven Ashina Spears',
@@ -21,15 +21,15 @@ const OPTIONS = [
 			'Ogres',
 			'Ashina Elites',
 		])),
-	])),
-	new Option('Defeat {0}', 100, S([
+	]),
+	F('Defeat {0}', S([
 		'Demon of Hatred',
 		'Father Owl',
 		'Sword Saint',
 		'3 Genichiros',
 	])),
-	new Option("Kill both mini/bosses in the Guardian Ape's Burrow", 100),
-	new Option('Find {0}', 100, S([
+	"Kill both mini/bosses in the Guardian Ape's Burrow",
+	F('Find {0}', S([
 		'Lotus of the Palace',
 		'Shelter Stone', 
 		'Aromatic Branch',
@@ -37,7 +37,7 @@ const OPTIONS = [
 		'Divine Dragon Tears',
 		'Aromatic Flower'
 	])),
-	new Option('Fit the {0} tool', 100, N(2, [
+	F('Fit the {0} tool', N(2, [
 		'Shuriken',
 		'Flame Vent',
 		'Firecrackers',
@@ -49,13 +49,13 @@ const OPTIONS = [
 		'Divine Abduction',
 		'Finger Whistle'
 	])),
-	new Option('Find {0} Ninjutsu', 100, S(['Puppeteer', 'Bloodsmoke', 'Bestowal'])),
-	new Option('Collect {0} prayer necklaces', 100, O([5, 6, 7, 8, 9, 10])),
-	new Option('Collect {0} gourd seeds', 100, O([5, 6, 7, 8, 9])),
-	new Option('Collect both Serpent Viscera', 100),
+	F('Find {0} Ninjutsu', S(['Puppeteer', 'Bloodsmoke', 'Bestowal'])),
+	F('Collect {0} prayer necklaces', O([5, 6, 7, 8, 9, 10])),
+	F('Collect {0} gourd seeds', O([5, 6, 7, 8, 9])),
+	'Collect both Serpent Viscera',
 	// 13 total: 9 sakes, 3 monkey boozes, 1 water of the palace
-	new Option('Collect {0} beverages', 100, R(6, 10)),
-	new Option('Learn the {0} skill', 100, N(2, [
+	F('Collect {0} beverages', R(6, 10)),
+	F('Learn the {0} skill', N(2, [
 		'Empowered Mortal Draw',
 		'Virtuous Deeds',
 		'Most Virtuous Deeds',
@@ -63,7 +63,7 @@ const OPTIONS = [
 		'Projected Force',
 		'Chasing Slice',
 	])),
-	new Option('Find {0} ', 100, S([
+	F('Find {0} ', S([
 		'Dragon Tally Board',
 		'Water of the Palace',
 		'Rice for Kuro',
@@ -71,9 +71,9 @@ const OPTIONS = [
 		'Great White Whisker',
 		'Red Carp Eyes',
 	])),
-	new Option('{0}', 100, O([
-		new Option('Possess at least {0} sen at some point', 100, R(5000, 15000)),
-		new Option('Buy all limited-stock items from {0} and {0}', 100, O([
+	O([
+		F('Possess at least {0} sen at some point', R(5000, 15000)),
+		F('Buy all limited-stock items from {0} and {0}', S([
 			"Crow's Bed Memorial Mob",
 			'Battlefield Memorial Mob',
 			'Blackhat Badger',
@@ -84,14 +84,14 @@ const OPTIONS = [
 			'Toxic Memorial Mob',
 			'Exiled Memorial Mob',
 		])),
-	])),
-	new Option('Find {0}', 100, S(['Purple Gourd', 'Green Gourd', 'Red Gourd'])),
-	new Option('{0}', 100, O([
-		new Option('Collect {0} carp scales', 100, R(5, 20)),
-		new Option('Buy all items from one Pot Noble', 100),
-	])),
-	new Option('Defeat {0} mini/bosses with Bell Demon (not Shizu/Noble)', 100, O([1, 2, 3])),
-	new Option('Upgrade to the {0}', 100, S([
+	]),
+	F('Find {0}', S(['Purple Gourd', 'Green Gourd', 'Red Gourd'])),
+	O([
+		F('Collect {0} carp scales', R(5, 20)),
+		'Buy all items from one Pot Noble',
+	]),
+	F('Defeat {0} mini/bosses with Bell Demon (not Shizu/Noble)', O([1, 2, 3])),
+	F('Upgrade to the {0}', S([
 		'Lazulite Axe',
 		'Sparking Axe',
 		'Spring-load Axe',
@@ -123,7 +123,7 @@ const OPTIONS = [
 		'Malcontent',
 		'Mountain Echo'
 	])),
-	new Option('Find {0}', 100, new SelectN(2, [
+	F('Find {0}', new SelectN(2, [
 		'Black Scroll',
 		"Dosaku's Note",
 		"Flame Barrel Memo",
@@ -145,45 +145,44 @@ const OPTIONS = [
 		"Three-Story Pagoda Memo",
 		"Valley Apparitions Memo"
 	])),
-	new Option('{0}', 100, N(3, [
-		new Option('Kill {0} memory bosses in one attempt', 100, O([1, 2, 3])),
-		new Option('Kill {0} minibosses in one attempt (not Shizu/Noble)', 100, O([4, 5, 6])),
-		new Option('Kill {0} mini/bosses without taking damage (not Shizu/Noble)', 100, O([4, 5, 6])),
+	N(3, [
+		F('Kill {0} memory bosses in one attempt', O([1, 2, 3])),
+		F('Kill {0} minibosses in one attempt (not Shizu/Noble)', O([4, 5, 6])),
+		F('Kill {0} mini/bosses without taking damage (not Shizu/Noble)', O([4, 5, 6])),
 		'Kill a mini/boss without attacking (except deathblows)',
 		'Kill a mini/boss without blocking/deflecting (not Shizu/Noble)',
 		'Kill a mini/boss without touching the control stick or arrow keys (not Shizu/Noble)',
 		'Kill a mini/boss using only combat arts (not Shizu/Noble)',
-	])),
-	new Option('Accumulate {0} skill points ({1} if skills are items)', 100, R(8, 12), R(16, 22)),
-	new Option('{0}', 100, N(2, [
-		new Option('Do not use {0}', 100, O(['any combat art', 'either Mortal Draw'])),
+	]),
+	F('Accumulate {0} skill points ({1} if skills are items)', R(8, 12), R(16, 22)),
+	N(2, [
+		F('Do not use {0}', O(['any combat art', 'either Mortal Draw'])),
 		'Never use a temporary buff item except Divine Confetti',
 		'Never use a stealth kill on a mini/boss',
-		new Option('Do not exceed {0} Attack Power', 100, O([4, 5, 6, 7, 8])),
+		F('Do not exceed {0} Attack Power', O([4, 5, 6, 7, 8])),
 		O([
 			'Never use a prosthetic tool in combat',
-			new Option('{0} use bladed prosthetic tools in combat', 100, O(['Exclusively', 'Never'])),
-			new Option('{0} use fire prosthetic tools in combat', 100, O(['Exclusively', 'Never'])),
-			new Option(
+			F('{0} use bladed prosthetic tools in combat', O(['Exclusively', 'Never'])),
+			F('{0} use fire prosthetic tools in combat', O(['Exclusively', 'Never'])),
+			F(
 				'Exclusively use prosthetic tools that cost {0} spirit emblems in combat',
-				100,
 				O([1, 2, 3])
 			),
 		]),
 		O([
-			new Option('Do not exceed {0} gourd charges', 100, O([3, 4, 5])),
-			new Option('Never use a healing consumable {0}', 100, S(['', 'except Pellets'])),
+			F('Do not exceed {0} gourd charges', O([3, 4, 5])),
+			F('Never use a healing consumable {0}', S(['', 'except Pellets'])),
 		]),
-	])),
-	new Option('Kill all enemies {0}', 100, S([
+	]),
+	F('Kill all enemies {0}', S([
 		'in the Senpou Temple attic',
 		"in Doujun's cave",
 		'guarding Monkey Booze in Bodhisattva Valley',
 		'in the Hidden Forest temple grove before clearing the mist',
 	])),
-	new Option('Kill the miniboss {0}', 100, S([
+	F('Kill the miniboss {0}', S([
 		'in Temple Grounds without using the rafters',
-		new Option('{0} without killing the mobs', 100, O([
+		F('{0} without killing the mobs', O([
 			'on the Ashina castle stairs',
 			'by the Hidden Forest campfire',
 			'in the Hirata Estate Main Hall',
@@ -192,7 +191,7 @@ const OPTIONS = [
 		])),
 		'in the tutorial'
 	])),
-	new Option('Kill the minibosses {0} and {0}', 100, O([
+	F('Kill the minibosses {0} and {0}', S([
 		'on the Ashina Castle stairs',
 		'in Temple Grounds',
 		'by the Water Mill',
@@ -205,14 +204,14 @@ const OPTIONS = [
 		'by the Hidden Forest campfire',
 		'on the Ashina Castle ground floor',
 	])),
-	new Option('Go from Bodhisattva Valley idol to Main Hall idol without resting, dying, or fast travel', 100),
-	new Option('Get {0} deathblows without resting, dying, or fast travel', 100, R(15, 30)),
-	new Option('{0}', 100, O([
-		new Option('Collect at least {0} {1}', 100, R(40, 60), O(['Scrap Iron', 'Scrap Magnetite'])),
-		new Option('Collect at least {0} {1}', 100, R(30, 45), O(['Adamantine Scrap', 'Black Gunpowder', 'Yellow Gunpowder'])),
-		new Option('Collect at least {0} {1}', 100, R(15, 25), O(['Fulminated Mercury', 'Lump of Fat Wax', 'Lump of Grave Wax'])),
-	])),
-]
+	'Go from Bodhisattva Valley idol to Main Hall idol without resting, dying, or fast travel',
+	F('Get {0} deathblows without resting, dying, or fast travel', R(15, 30)),
+	O([
+		F('Collect at least {0} {1}', R(40, 60), O(['Scrap Iron', 'Scrap Magnetite'])),
+		F('Collect at least {0} {1}', R(30, 45), O(['Adamantine Scrap', 'Black Gunpowder', 'Yellow Gunpowder'])),
+		F('Collect at least {0} {1}', R(15, 25), O(['Fulminated Mercury', 'Lump of Fat Wax', 'Lump of Grave Wax'])),
+	]),
+]);
 
 var BINGO = new Bingo(OPTIONS);
 

--- a/bingo/web/sekiro/index.js
+++ b/bingo/web/sekiro/index.js
@@ -26,8 +26,9 @@ const OPTIONS = [
 		'Demon of Hatred',
 		'Father Owl',
 		'Sword Saint',
+		'3 Genichiros',
 	])),
-	new Option("Kill both bosses in the Guardian Ape's Burrow", 100),
+	new Option("Kill both mini/bosses in the Guardian Ape's Burrow", 100),
 	new Option('Find {0}', 100, S([
 		'Lotus of the Palace',
 		'Shelter Stone', 
@@ -36,7 +37,7 @@ const OPTIONS = [
 		'Divine Dragon Tears',
 		'Aromatic Flower'
 	])),
-	new Option('Find {0}', 100, N(2, [
+	new Option('Fit the {0} tool', 100, N(2, [
 		'Shuriken',
 		'Flame Vent',
 		'Firecrackers',
@@ -53,7 +54,7 @@ const OPTIONS = [
 	new Option('Collect {0} gourd seeds', 100, O([5, 6, 7, 8, 9])),
 	new Option('Collect both Serpent Viscera', 100),
 	// 13 total: 9 sakes, 3 monkey boozes, 1 water of the palace
-	new Option('Collect {0} beverages', 100, O([5, 6, 7, 8, 9])),
+	new Option('Collect {0} beverages', 100, R(6, 10)),
 	new Option('Learn the {0} skill', 100, N(2, [
 		'Empowered Mortal Draw',
 		'Virtuous Deeds',
@@ -89,7 +90,7 @@ const OPTIONS = [
 		new Option('Collect {0} carp scales', 100, R(5, 20)),
 		new Option('Buy all items from one Pot Noble', 100),
 	])),
-	new Option('Defeat {0} bosses with Bell Demon (not Shizu/Noble)', 100, O([1, 2, 3])),
+	new Option('Defeat {0} mini/bosses with Bell Demon (not Shizu/Noble)', 100, O([1, 2, 3])),
 	new Option('Upgrade to the {0}', 100, S([
 		'Lazulite Axe',
 		'Sparking Axe',
@@ -144,34 +145,51 @@ const OPTIONS = [
 		"Three-Story Pagoda Memo",
 		"Valley Apparitions Memo"
 	])),
-	new Option('{0}', 100, N(2, [
+	new Option('{0}', 100, N(3, [
 		new Option('Kill {0} memory bosses in one attempt', 100, O([1, 2, 3])),
 		new Option('Kill {0} minibosses in one attempt (not Shizu/Noble)', 100, O([4, 5, 6])),
-		new Option('Kill {0} bosses without taking damage (not Shizu/Noble)', 100, O([4, 5, 6])),
-		new Option('Kill a boss without attacking (except deathblows)', 100),
-		new Option('Kill a boss without blocking/deflecting (not Shizu/Noble)', 100),
+		new Option('Kill {0} mini/bosses without taking damage (not Shizu/Noble)', 100, O([4, 5, 6])),
+		'Kill a mini/boss without attacking (except deathblows)',
+		'Kill a mini/boss without blocking/deflecting (not Shizu/Noble)',
+		'Kill a mini/boss without touching the control stick or arrow keys (not Shizu/Noble)',
+		'Kill a mini/boss using only combat arts (not Shizu/Noble)',
 	])),
-	new Option('Accumulate 10 skill points (20 if skills are items)', 100),
+	new Option('Accumulate {0} skill points ({1} if skills are items)', 100, R(8, 12), R(16, 22)),
 	new Option('{0}', 100, N(2, [
 		new Option('Do not use {0}', 100, O(['any combat art', 'either Mortal Draw'])),
-		'Never use a temporary buff item',
-		'Never use a prosthetic tool in combat',
-		new Option('Never use a stealth kill {0}', 100, O(['', 'on a boss'])),
+		'Never use a temporary buff item except Divine Confetti',
+		'Never use a stealth kill on a mini/boss',
 		new Option('Do not exceed {0} Attack Power', 100, O([4, 5, 6, 7, 8])),
+		O([
+			'Never use a prosthetic tool in combat',
+			new Option('{0} use bladed prosthetic tools in combat', 100, O(['Exclusively', 'Never'])),
+			new Option('{0} use fire prosthetic tools in combat', 100, O(['Exclusively', 'Never'])),
+			new Option(
+				'Exclusively use prosthetic tools that cost {0} spirit emblems in combat',
+				100,
+				O([1, 2, 3])
+			),
+		]),
 		O([
 			new Option('Do not exceed {0} gourd charges', 100, O([3, 4, 5])),
 			new Option('Never use a healing consumable {0}', 100, S(['', 'except Pellets'])),
 		]),
 	])),
-	new Option('Kill all enemies {0}', 100, O([
+	new Option('Kill all enemies {0}', 100, S([
 		'in the Senpou Temple attic',
 		"in Doujun's cave",
 		'guarding Monkey Booze in Bodhisattva Valley',
+		'in the Hidden Forest temple grove before clearing the mist',
 	])),
 	new Option('Kill the miniboss {0}', 100, S([
 		'in Temple Grounds without using the rafters',
-		'in Bamboo Thicket Slope without leaving the courtyard',
-		'on the Ashina Castle stairs without killing the mobs',
+		new Option('{0} without killing the mobs', 100, O([
+			'on the Ashina castle stairs',
+			'by the Hidden Forest campfire',
+			'in the Hirata Estate Main Hall',
+			'before the Ashina Castle idol',
+			'before the Underbridge Valley idol',
+		])),
 		'in the tutorial'
 	])),
 	new Option('Kill the minibosses {0} and {0}', 100, O([
@@ -186,6 +204,13 @@ const OPTIONS = [
 		'in the Serpent Shrine',
 		'by the Hidden Forest campfire',
 		'on the Ashina Castle ground floor',
+	])),
+	new Option('Go from Bodhisattva Valley idol to Main Hall idol without resting, dying, or fast travel', 100),
+	new Option('Get {0} deathblows without resting, dying, or fast travel', 100, R(15, 30)),
+	new Option('{0}', 100, O([
+		new Option('Collect at least {0} {1}', 100, R(40, 60), O(['Scrap Iron', 'Scrap Magnetite'])),
+		new Option('Collect at least {0} {1}', 100, R(30, 45), O(['Adamantine Scrap', 'Black Gunpowder', 'Yellow Gunpowder'])),
+		new Option('Collect at least {0} {1}', 100, R(15, 25), O(['Fulminated Mercury', 'Lump of Fat Wax', 'Lump of Grave Wax'])),
 	])),
 ]
 


### PR DESCRIPTION
This splits the option specification into two phases:

* First, the structure that's actually written in the JS file for a
 given game. This is an immutable structure that's shared across
 bingo boards, and is optimized for ease of human reading and
 writing. It's roughly the same structure as before, except that
 "formatting a string" and "specifying a weight" are now separate
 concerns handled by separate wrapper functions.

* Then when it's time to generate a new bingo board, this structure is
 used to generate a *mutable* structure. Most importantly, this
 allows a *nested* `SelectN` to restrict how often it's chosen
 without also restricting whatever option contains it.